### PR TITLE
ci: update actions to v4 and add Node 24 to test matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,17 +2,22 @@ name: Node.js CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
- Update `actions/checkout` from v2 to v4
- Update `actions/setup-node` from v2 to v4
- Add Node.js 24.x to the CI matrix
- Add `permissions: contents: read` for security hardening
- Add `persist-credentials: false` to checkout step

All tests continue to pass on Node 18.x, 20.x, 22.x, and 24.x.