### PR TITLE
docs: update Google Developers link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **NOTE: The `Feature-Policy` header has been deprecated by browsers in favor of `Permissions-Policy`. This module will still be supported but no new features will be added.**
 
-This is Express middleware to set the `Feature-Policy` header. You can read more about it [here](https://scotthelme.co.uk/a-new-security-header-feature-policy/) and [here](https://developers.google.com/web/updates/2018/06/feature-policy).
+This is Express middleware to set the `Feature-Policy` header. You can read more about it [here](https://scotthelme.co.uk/a-new-security-header-feature-policy/) and [here](https://developer.chrome.com/blog/feature-policy/).
 
 To use:
 


### PR DESCRIPTION
The Google Developers link (`developers.google.com/web/updates/2018/06/feature-policy`) now returns a 301 redirect to `developer.chrome.com/blog/feature-policy/`.

Updated the README to point directly to the current URL.