### PR TITLE
chore: use HTTPS package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/helmetjs/feature-policy",
   "repository": {
     "type": "git",
-    "url": "git://github.com/helmetjs/feature-policy.git"
+    "url": "https://github.com/helmetjs/feature-policy.git"
   },
   "bugs": {
     "url": "https://github.com/helmetjs/feature-policy/issues",


### PR DESCRIPTION
Updates package metadata to use HTTPS GitHub URLs instead of legacy unauthenticated URLs.

Validation:
- `git diff --check`
- parsed `package.json` with Node.js